### PR TITLE
Add media to posts

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -15,7 +15,7 @@ module Api
       def show
          render json: @response
       end
-      
+
       # view a comment
       def show_comment
         if @comment = @comments.find_by_id(params[:comment_id])
@@ -32,7 +32,7 @@ module Api
 
       # create a post
       def create
-          @post = Post.new({body: post_params})
+          @post = Post.new(post_params)
           @post.bot = @current_bot
           if @post.save
             render json: { message: "Post created: #{@post.id}", data: @post }, status: :created
@@ -53,13 +53,13 @@ module Api
       private
 
       def post_params
-        params.require(:body)
+        params.permit(:body, :media)
       end
 
       def set_post
         @post = Post.select(:id, :body, :username, :bot_id).joins(:bot).find(params[:id])
         @comments = Comment.select(:id, :body).where(post_id: @post.id)
-       	@likes = @post.likes.count     			
+       	@likes = @post.likes.count
       end
 
       def set_response
@@ -76,7 +76,7 @@ module Api
           render json: { status: 'ERROR', message: 'Bad credentials' }, status: :unauthorized
         end
       end
-      
+
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,8 @@ class Post < ApplicationRecord
 
     has_many :comments, dependent: :destroy
     has_many :likes, dependent: :destroy
+
+    validates_presence_of :body # body is required
+
+    mount_uploader :media, MediaUploader
 end

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -10,7 +10,12 @@ class MediaUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   def extension_allowlist
-    %w(jpg jpeg gif png mp4)
+    %w[jpg jpeg gif png mp4]
+  end
+
+  # define min and max upload file size
+  def size_range
+    1.byte..8.megabytes
   end
 
   # Override the filename of the uploaded files.

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -10,7 +10,7 @@ class MediaUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   def extension_allowlist
-    %w(jpg jpeg gif png mp4 mkv)
+    %w(jpg jpeg gif png mp4)
   end
 
   # Override the filename of the uploaded files.

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -1,16 +1,11 @@
 class MediaUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
-  
+
   storage :file
 
   # Override the directory where uploaded files will be stored.
   def store_dir
     "../../iae/public/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  def default_url(*args)
-    "../../iae/app/assets/images/fallback/" + ["default.png"].compact.join('_')
   end
 
   # Add an allowlist of extensions which are allowed to be uploaded.

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -14,7 +14,7 @@ class MediaUploader < CarrierWave::Uploader::Base
   end
 
   # Override the filename of the uploaded files.
-  def filename
-    "#{model.id}.#{file.extension}" if original_filename.present?
-  end
+  # def filename
+  #   model.file_identifier if original_filename
+  # end
 end

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -10,7 +10,7 @@ class MediaUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   def extension_allowlist
-    %w[jpg jpeg gif png mp4]
+    %w[jpg jpeg gif png mp4 gif]
   end
 
   # define min and max upload file size

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -1,0 +1,25 @@
+class MediaUploader < CarrierWave::Uploader::Base
+  # include CarrierWave::MiniMagick
+  
+  storage :file
+
+  # Override the directory where uploaded files will be stored.
+  def store_dir
+    "../../iae/public/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  def default_url(*args)
+    "../../iae/app/assets/images/fallback/" + ["default.png"].compact.join('_')
+  end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  def extension_allowlist
+    %w(jpg jpeg gif png mp4 mkv)
+  end
+
+  # Override the filename of the uploaded files.
+  def filename
+    "#{model.id}.#{file.extension}" if original_filename.present?
+  end
+end

--- a/db/migrate/20210319161503_add_media_to_posts.rb
+++ b/db/migrate/20210319161503_add_media_to_posts.rb
@@ -1,0 +1,5 @@
+class AddMediaToPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :posts, :media, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_18_034223) do
+ActiveRecord::Schema.define(version: 2021_03_19_161503) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2021_03_18_034223) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "bot_id", null: false
+    t.string "media"
     t.index ["bot_id"], name: "index_posts_on_bot_id"
   end
 


### PR DESCRIPTION
### Add media to posts - Closes #22 

- Formats permitted: jpg, jpeg, png, mp4 and gif;
- Files can't be larger than 8MB.

It's required to migrate your database. 